### PR TITLE
fix/copyright year dynamic in footer

### DIFF
--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -7,6 +7,8 @@ import {
 } from '@chakra-ui/react';
 
 export default function Footer() {
+    const currentYear = new Date().getFullYear();
+
     return (
         <Box
      
@@ -26,7 +28,7 @@ export default function Footer() {
                 spacing={4}
                 justify={{ base: 'center', md: 'center' }}
                 align={{ base: 'center', md: 'center' }}>
-                <Text>© 2022 Currency Converter. All rights reserved</Text>
+                <Text>© {currentYear} Currency Converter. All rights reserved</Text>
             </Container>
         </Box>
     );


### PR DESCRIPTION
fixes: #15 
Made the footer to show the latest copyright year
screenshot : 
![image](https://github.com/imhardikdesai/Currency-Converter/assets/111238447/74a8e743-c426-4c4d-af8e-faf9596175b8)
