### PR TITLE
[STYLING] Fixed Styling inconsistencies in the form

### DIFF
--- a/src/components/Form/Form.jsx
+++ b/src/components/Form/Form.jsx
@@ -99,7 +99,7 @@ const Form = () => {
                 px={"8px"}
                 py={"12px"}
                 fontSize={"1.3rem"}
-                mx={"1"}
+                ml={"1"}
                 ref={ref}
                 onClick={resetHandler}
                 colorScheme="teal"
@@ -116,6 +116,8 @@ const Form = () => {
                 onChange={setFromCountryHandler}
                 variant={"filled"}
                 placeholder="Select country"
+                size="md"
+                rounded={"md"}
               >
                 {countryData.map((country, index) => {
                   return (
@@ -134,6 +136,8 @@ const Form = () => {
                 onChange={setToCountryHandler}
                 variant={"filled"}
                 placeholder="Select country"
+                size="md"
+                rounded={"md"}
               >
                 {countryData.map((country, index) => {
                   return (


### PR DESCRIPTION
Fixed minor inconsistencies in the styling of the converter form.

### Margin on the Reset Button:
Current:
![image](https://github.com/imhardikdesai/Currency-Converter/assets/107793187/8eadb348-e4da-4328-8a12-e75b735a0de8)
Fixed:
![image](https://github.com/imhardikdesai/Currency-Converter/assets/107793187/be8d910f-cbd4-4909-a033-b778f5902aba)

### Size and rounded corners on the Currency select
Current:
![image](https://github.com/imhardikdesai/Currency-Converter/assets/107793187/e7b28e75-60d6-4e11-98c6-97006af13352)
Fixed:
![image](https://github.com/imhardikdesai/Currency-Converter/assets/107793187/4f6db690-afc1-499b-b728-3dd707c7d6a7)
